### PR TITLE
Improvement - Refine system symbols filtering

### DIFF
--- a/Mac-App/Backend/Backend.xcodeproj/project.pbxproj
+++ b/Mac-App/Backend/Backend.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A8199C5623E700A5000B89F6 /* AppDelegateSwiftDepsFixture.swiftDeps in Resources */ = {isa = PBXBuildFile; fileRef = A8199C5523E700A5000B89F6 /* AppDelegateSwiftDepsFixture.swiftDeps */; };
 		A831004223DC9E4400460A12 /* Backend.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A831003823DC9E4400460A12 /* Backend.framework */; };
 		A831004923DC9E4400460A12 /* Backend.h in Headers */ = {isa = PBXBuildFile; fileRef = A831003B23DC9E4400460A12 /* Backend.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A84DAD31244C7F01005EAB59 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84DAD30244C7F01005EAB59 /* Collection.swift */; };
 		A85514EF23E5E6AA00D3E7F6 /* YamlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85514EE23E5E6AA00D3E7F6 /* YamlParser.swift */; };
 		A85514F123E6002500D3E7F6 /* SwiftDepsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85514F023E6002500D3E7F6 /* SwiftDepsState.swift */; };
 		A85514F423E6015E00D3E7F6 /* SwiftDepsReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85514F323E6015E00D3E7F6 /* SwiftDepsReducer.swift */; };
@@ -98,6 +99,7 @@
 		A831003C23DC9E4400460A12 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A831004123DC9E4400460A12 /* BackendTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BackendTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A831004823DC9E4400460A12 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A84DAD30244C7F01005EAB59 /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		A85514EE23E5E6AA00D3E7F6 /* YamlParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamlParser.swift; sourceTree = "<group>"; };
 		A85514F023E6002500D3E7F6 /* SwiftDepsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDepsState.swift; sourceTree = "<group>"; };
 		A85514F323E6015E00D3E7F6 /* SwiftDepsReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDepsReducer.swift; sourceTree = "<group>"; };
@@ -233,6 +235,14 @@
 			path = BackendTests;
 			sourceTree = "<group>";
 		};
+		A84DAD2F244C7EED005EAB59 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				A84DAD30244C7F01005EAB59 /* Collection.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		A85514ED23E5E68000D3E7F6 /* Yaml */ = {
 			isa = PBXGroup;
 			children = (
@@ -252,6 +262,7 @@
 		A89E0BE023F87D850009154E /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				A84DAD2F244C7EED005EAB59 /* Extensions */,
 				A89E0BE123F87DAC0009154E /* DispatchQueue+Shorthands.swift */,
 			);
 			path = Shared;
@@ -641,6 +652,7 @@
 				A8E7626B23DDB9F000BFAD48 /* AppState.swift in Sources */,
 				A89E0BDF23F87AD70009154E /* DependencyGraphSideEffects.swift in Sources */,
 				A8D58A9323F67F8900C2AB74 /* SwiftDepsParser.swift in Sources */,
+				A84DAD31244C7F01005EAB59 /* Collection.swift in Sources */,
 				A85514F623E6030100D3E7F6 /* ParseSwiftDepsSideEffects.swift in Sources */,
 				A89E0BE223F87DAC0009154E /* DispatchQueue+Shorthands.swift in Sources */,
 				A8199C5123E6CA73000B89F6 /* SwiftDeps.swift in Sources */,

--- a/Mac-App/Backend/Backend/Parsers/SwiftDepsParser/SwiftDepsParser.swift
+++ b/Mac-App/Backend/Backend/Parsers/SwiftDepsParser/SwiftDepsParser.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 Acphut Werkstatt. All rights reserved.
 //
 
-/// Parsing omits private declarations, ocurrances of `Self`, system symbols (see `systemSymbols` declarion)
-/// and objects with `NS` prefix
+/// Parsing omits private declarations, ocurrances of `Self`, system symbols (see `systemSymbols` declaration)
+/// as well as objects with with common framework prefixes: `NS`, `UI` & `CF` (list might need to be updated later)
 
 func parseSwiftDeps(_ swiftDeps: [SwiftDeps]) -> [DependencyTree] {
     var result = [DependencyTree]()

--- a/Mac-App/Backend/Backend/Parsers/SwiftDepsParser/SwiftDepsParser.swift
+++ b/Mac-App/Backend/Backend/Parsers/SwiftDepsParser/SwiftDepsParser.swift
@@ -18,9 +18,9 @@ func parseSwiftDeps(_ swiftDeps: [SwiftDeps]) -> [DependencyTree] {
                 let deps = dep.dependsTopLevel
                     .filter { $0.tag.description != "!private" }
                     .compactMap { (try? $0.represented().string) }
-                    .filterOcurrancesOf(name)
                     .excludeSystemSymbols()
                     .excludeSystemSymbolsPrefixes()
+                    .filterOcurrancesOf(name)
                     .map(DependencyTree.Dependency.init)
 
                 result.append(DependencyTree(owner: name, dependencies: deps))

--- a/Mac-App/Backend/Backend/Parsers/SwiftDepsParser/SwiftDepsParser.swift
+++ b/Mac-App/Backend/Backend/Parsers/SwiftDepsParser/SwiftDepsParser.swift
@@ -18,9 +18,9 @@ func parseSwiftDeps(_ swiftDeps: [SwiftDeps]) -> [DependencyTree] {
                 let deps = dep.dependsTopLevel
                     .filter { $0.tag.description != "!private" }
                     .compactMap { (try? $0.represented().string) }
-                    .filter { $0 != name }
-                    .filter { systemSymbols.contains($0) == false }
-                    .filter { $0.contains("NS") == false }
+                    .filterOcurrancesOf(name)
+                    .excludeSystemSymbols()
+                    .excludeSystemSymbolsPrefixes()
                     .map(DependencyTree.Dependency.init)
 
                 result.append(DependencyTree(owner: name, dependencies: deps))

--- a/Mac-App/Backend/Backend/Shared/Extensions/Collection.swift
+++ b/Mac-App/Backend/Backend/Shared/Extensions/Collection.swift
@@ -1,0 +1,19 @@
+extension Collection where Element == String {
+    func filterOcurrancesOf(_ string: String) -> [Element] {
+        filter { $0 != string }
+    }
+
+    // MARK: - System symbols filtering
+
+    func excludeSystemSymbols() -> [Element] {
+        filter { systemSymbols.contains($0) == false }
+    }
+
+    func excludeSystemSymbolsPrefixes() -> [Element] {
+        filter {
+            $0.contains("NS") == false &&
+                $0.contains("UI") == false &&
+                $0.contains("CF") == false
+        }
+    }
+}

--- a/Mac-App/Backend/BackendTests/Parsers/SwiftDeps/SwiftDepsParserSpec.swift
+++ b/Mac-App/Backend/BackendTests/Parsers/SwiftDeps/SwiftDepsParserSpec.swift
@@ -14,14 +14,38 @@ final class SwiftDepsParserSpec: QuickSpec {
     override func spec() {
         describe("parseSwiftDeps") {
             context("given it takes a valid input") {
-                it("returns correctly parsed DependencyTree objects") {
-                    let result = parseSwiftDeps(
-                        parseYamlUrls(
-                            from: findProjectOutputDirectories(projectName: "Backend")
-                        )
-                    )
+                var result: [DependencyTree] = []
 
+                beforeEach {
+                    // Do not perform same search for each test case as the results are the same
+                    // And it is expensive & long
+                    if result.isEmpty == true {
+                        result = parseSwiftDeps(
+                            parseYamlUrls(
+                                from: findProjectOutputDirectories(projectName: "Backend")
+                            )
+                        )
+                    }
+                }
+
+                it("returns correctly parsed DependencyTree objects") {
                     expect(result).notTo(beEmpty())
+                }
+
+                it("does not store the owner name in the dependencies list") {
+                    let randomItem = result.randomElement()!
+                    let randomItemDeps = randomItem.dependencies.map { $0.name }
+                    expect(randomItemDeps.contains(randomItem.owner)).to(beFalse())
+                }
+
+                it("does not include any system/framework symbols") {
+                    let randomItem = result.randomElement()!
+                    let randomItemDeps = randomItem.dependencies.map { $0.name }
+
+                    expect(randomItemDeps.contains(systemSymbols.randomElement()!)).to(beFalse())
+                    expect(randomItemDeps.randomElement()!.contains("UI")).to(beFalse())
+                    expect(randomItemDeps.randomElement()!.contains("NS")).to(beFalse())
+                    expect(randomItemDeps.randomElement()!.contains("CF")).to(beFalse())
                 }
             }
 

--- a/Mac-App/Backend/BackendTests/Parsers/SwiftDeps/SwiftDepsParserSpec.swift
+++ b/Mac-App/Backend/BackendTests/Parsers/SwiftDeps/SwiftDepsParserSpec.swift
@@ -19,7 +19,7 @@ final class SwiftDepsParserSpec: QuickSpec {
                 beforeEach {
                     // Do not perform same search for each test case as the results are the same
                     // And it is expensive & long
-                    if result.isEmpty == true {
+                    if result.isEmpty {
                         result = parseSwiftDeps(
                             parseYamlUrls(
                                 from: findProjectOutputDirectories(projectName: "Backend")

--- a/Mac-App/Mac-App/Transformers/DetailsViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/DetailsViewTransformer.swift
@@ -52,4 +52,3 @@ extension DetailsViewTransformer {
         case failure(_ failure: String)
     }
 }
-


### PR DESCRIPTION
Split down the filtering process into collection extensions so the compiler checker can be satisfied. 

Also added tests cases for these scenarios. 