### PR TITLE
Infrastructure - Composable State Observer

### DIFF
--- a/Mac-App/Backend/Backend/BackendAPI/BackendAPI.swift
+++ b/Mac-App/Backend/Backend/BackendAPI/BackendAPI.swift
@@ -30,4 +30,11 @@ public enum BackendAPI {
         where AppState == S.StoreSubscriberStateType, S: ReSwift.StoreSubscriber {
         BackendAPI.store.subscribe(subscriber)
     }
+
+    public static func subscribeToSubstate<SelectedState, S>(
+        _ subscriber: S,
+        transform: ((ReSwift.Subscription<AppState>) -> ReSwift.Subscription<SelectedState>)?
+    ) where SelectedState == S.StoreSubscriberStateType, S: ReSwift.StoreSubscriber {
+        BackendAPI.store.subscribe(subscriber, transform: transform)
+    }
 }

--- a/Mac-App/Backend/Backend/BackendAPI/BackendAPI.swift
+++ b/Mac-App/Backend/Backend/BackendAPI/BackendAPI.swift
@@ -31,7 +31,7 @@ public enum BackendAPI {
         BackendAPI.store.subscribe(subscriber)
     }
 
-    public static func subscribeToSubstate<SelectedState, S>(
+    public static func subscribe<SelectedState, S>(
         _ subscriber: S,
         transform: ((ReSwift.Subscription<AppState>) -> ReSwift.Subscription<SelectedState>)?
     ) where SelectedState == S.StoreSubscriberStateType, S: ReSwift.StoreSubscriber {

--- a/Mac-App/Frontend/Frontend/ViewData/DependencyTreeViewData.swift
+++ b/Mac-App/Frontend/Frontend/ViewData/DependencyTreeViewData.swift
@@ -13,9 +13,11 @@ public enum DependencyTreeView {
 
     public struct Data: Equatable {
         public let dependencies: [Dependency]
+        public let failure: String?
 
-        public init(dependencies: [Dependency]) {
+        public init(dependencies: [Dependency], failure: String?) {
             self.dependencies = dependencies.sorted(by: { $0.dependencies.count > $1.dependencies.count })
+            self.failure = failure
         }
 
         public struct Dependency: Equatable, Identifiable {

--- a/Mac-App/Mac-App.xcodeproj/project.pbxproj
+++ b/Mac-App/Mac-App.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		A86E103B2365DAB800D3FF94 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A86E103A2365DAB800D3FF94 /* Preview Assets.xcassets */; };
 		A86E103E2365DAB900D3FF94 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A86E103C2365DAB900D3FF94 /* Main.storyboard */; };
 		A8743A6F245F28BF00F8BFF2 /* registerSubscribers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8743A6E245F28BF00F8BFF2 /* registerSubscribers.swift */; };
+		A8743A72245F2B1B00F8BFF2 /* StateObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8743A71245F2B1B00F8BFF2 /* StateObserver.swift */; };
 		A89E0BE423F883AA0009154E /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A89E0BE323F883AA0009154E /* ReSwift.framework */; };
 		A89E0BE523F883AA0009154E /* ReSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A89E0BE323F883AA0009154E /* ReSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A8CAE9AA23DCAE7E00242ADF /* Mac-AppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CAE9A923DCAE7E00242ADF /* Mac-AppTests.swift */; };
@@ -58,6 +59,7 @@
 		A86E10452365DAB900D3FF94 /* Mac-AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Mac-AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A86E104B2365DAB900D3FF94 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A8743A6E245F28BF00F8BFF2 /* registerSubscribers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerSubscribers.swift; sourceTree = "<group>"; };
+		A8743A71245F2B1B00F8BFF2 /* StateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateObserver.swift; sourceTree = "<group>"; };
 		A89E0BE323F883AA0009154E /* ReSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReSwift.framework; path = Backend/Dependencies/macOS/ReSwift.framework; sourceTree = "<group>"; };
 		A8CAE9A923DCAE7E00242ADF /* Mac-AppTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Mac-AppTests.swift"; sourceTree = "<group>"; };
 		A8F2525F2400526200CD12DE /* Frontend.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Frontend.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -126,6 +128,7 @@
 		A86E10322365DAB800D3FF94 /* Mac-App */ = {
 			isa = PBXGroup;
 			children = (
+				A8743A70245F2B0900F8BFF2 /* StateObserver */,
 				A8743A6D245F289D00F8BFF2 /* BackendSubscribers */,
 				A8472C9C2402C6040032E702 /* Transformers */,
 				A86E10332365DAB800D3FF94 /* AppDelegate.swift */,
@@ -161,6 +164,14 @@
 				A8743A6E245F28BF00F8BFF2 /* registerSubscribers.swift */,
 			);
 			path = BackendSubscribers;
+			sourceTree = "<group>";
+		};
+		A8743A70245F2B0900F8BFF2 /* StateObserver */ = {
+			isa = PBXGroup;
+			children = (
+				A8743A71245F2B1B00F8BFF2 /* StateObserver.swift */,
+			);
+			path = StateObserver;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -289,6 +300,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A8743A6F245F28BF00F8BFF2 /* registerSubscribers.swift in Sources */,
+				A8743A72245F2B1B00F8BFF2 /* StateObserver.swift in Sources */,
 				A86E10342365DAB800D3FF94 /* AppDelegate.swift in Sources */,
 				A8FECAAB24310DDC0028CC64 /* DetailsViewTransformer.swift in Sources */,
 				A8472C9E2402C6190032E702 /* ListViewTransformer.swift in Sources */,

--- a/Mac-App/Mac-App.xcodeproj/project.pbxproj
+++ b/Mac-App/Mac-App.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		A86E10382365DAB800D3FF94 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A86E10372365DAB800D3FF94 /* Assets.xcassets */; };
 		A86E103B2365DAB800D3FF94 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A86E103A2365DAB800D3FF94 /* Preview Assets.xcassets */; };
 		A86E103E2365DAB900D3FF94 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A86E103C2365DAB900D3FF94 /* Main.storyboard */; };
+		A8743A6F245F28BF00F8BFF2 /* registerSubscribers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8743A6E245F28BF00F8BFF2 /* registerSubscribers.swift */; };
 		A89E0BE423F883AA0009154E /* ReSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A89E0BE323F883AA0009154E /* ReSwift.framework */; };
 		A89E0BE523F883AA0009154E /* ReSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A89E0BE323F883AA0009154E /* ReSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A8CAE9AA23DCAE7E00242ADF /* Mac-AppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CAE9A923DCAE7E00242ADF /* Mac-AppTests.swift */; };
@@ -56,6 +57,7 @@
 		A86E10402365DAB900D3FF94 /* Mac_App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Mac_App.entitlements; sourceTree = "<group>"; };
 		A86E10452365DAB900D3FF94 /* Mac-AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Mac-AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A86E104B2365DAB900D3FF94 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A8743A6E245F28BF00F8BFF2 /* registerSubscribers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = registerSubscribers.swift; sourceTree = "<group>"; };
 		A89E0BE323F883AA0009154E /* ReSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReSwift.framework; path = Backend/Dependencies/macOS/ReSwift.framework; sourceTree = "<group>"; };
 		A8CAE9A923DCAE7E00242ADF /* Mac-AppTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Mac-AppTests.swift"; sourceTree = "<group>"; };
 		A8F2525F2400526200CD12DE /* Frontend.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Frontend.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -124,6 +126,7 @@
 		A86E10322365DAB800D3FF94 /* Mac-App */ = {
 			isa = PBXGroup;
 			children = (
+				A8743A6D245F289D00F8BFF2 /* BackendSubscribers */,
 				A8472C9C2402C6040032E702 /* Transformers */,
 				A86E10332365DAB800D3FF94 /* AppDelegate.swift */,
 				A86E10372365DAB800D3FF94 /* Assets.xcassets */,
@@ -150,6 +153,14 @@
 				A86E104B2365DAB900D3FF94 /* Info.plist */,
 			);
 			path = "Mac-AppTests";
+			sourceTree = "<group>";
+		};
+		A8743A6D245F289D00F8BFF2 /* BackendSubscribers */ = {
+			isa = PBXGroup;
+			children = (
+				A8743A6E245F28BF00F8BFF2 /* registerSubscribers.swift */,
+			);
+			path = BackendSubscribers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -277,6 +288,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8743A6F245F28BF00F8BFF2 /* registerSubscribers.swift in Sources */,
 				A86E10342365DAB800D3FF94 /* AppDelegate.swift in Sources */,
 				A8FECAAB24310DDC0028CC64 /* DetailsViewTransformer.swift in Sources */,
 				A8472C9E2402C6190032E702 /* ListViewTransformer.swift in Sources */,

--- a/Mac-App/Mac-App/AppDelegate.swift
+++ b/Mac-App/Mac-App/AppDelegate.swift
@@ -19,7 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let contentView = InputView { value in
             BackendAPI.dispatch(DependencyPathsAction.findUrls(for: value))
 
-            let mainSplitView = MainSplitView(viewData: listviewSubscriber.transformedData)
+            let mainSplitView = MainSplitView(viewData: listViewTransformer.transformedData)
             self.window.contentView = NSHostingView(rootView: mainSplitView)
         }
 

--- a/Mac-App/Mac-App/AppDelegate.swift
+++ b/Mac-App/Mac-App/AppDelegate.swift
@@ -39,9 +39,3 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Insert code here to tear down your application
     }
 }
-
-private func registerSubscribers() {
-    BackendAPI.subscribe(listviewSubscriber)
-}
-
-let listviewSubscriber = ListViewTransformer()

--- a/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
+++ b/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
@@ -7,10 +7,11 @@
 //
 
 import Backend
+import Frontend
 
 func registerSubscribers() {
-    BackendAPI.subscribe(listViewTransformer.stateObserver)
-    BackendAPI.subscribe(detailsViewTransformer.stateObserver)
+    BackendAPI.subscribeToSubstate(listViewTransformer.stateObserver) { $0.select(DependencyTreeView.Data.init) }
+    BackendAPI.subscribeToSubstate(detailsViewTransformer.stateObserver) { $0.select(ProjectFactsViewData.Data.init) }
 
     startListening()
 }

--- a/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
+++ b/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
@@ -9,7 +9,7 @@
 import Backend
 
 func registerSubscribers() {
-    BackendAPI.subscribe(listviewSubscriber)
+    BackendAPI.subscribe(listViewTransformer)
     BackendAPI.subscribe(detailsViewTransformer.stateObserver)
 
     startListening()
@@ -25,5 +25,5 @@ private func stopListening() {
 
 // MARK: Transformers
 
-let listviewSubscriber = ListViewTransformer()
+let listViewTransformer = ListViewTransformer()
 let detailsViewTransformer = DetailsViewTransformer()

--- a/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
+++ b/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
@@ -21,6 +21,7 @@ private func startListening() {
 }
 
 private func stopListening() {
+    listViewTransformer.stopListening()
     detailsViewTransformer.stopListening()
 }
 

--- a/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
+++ b/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
@@ -10,8 +10,8 @@ import Backend
 import Frontend
 
 func registerSubscribers() {
-    BackendAPI.subscribeToSubstate(listViewTransformer.stateObserver) { $0.select(DependencyTreeView.Data.init) }
-    BackendAPI.subscribeToSubstate(detailsViewTransformer.stateObserver) { $0.select(ProjectFactsViewData.Data.init) }
+    BackendAPI.subscribe(listViewTransformer.stateObserver) { $0.select(DependencyTreeView.Data.init) }
+    BackendAPI.subscribe(detailsViewTransformer.stateObserver) { $0.select(ProjectFactsViewData.Data.init) }
 
     startListening()
 }

--- a/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
+++ b/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
@@ -9,13 +9,14 @@
 import Backend
 
 func registerSubscribers() {
-    BackendAPI.subscribe(listViewTransformer)
+    BackendAPI.subscribe(listViewTransformer.stateObserver)
     BackendAPI.subscribe(detailsViewTransformer.stateObserver)
 
     startListening()
 }
 
 private func startListening() {
+    listViewTransformer.startListening()
     detailsViewTransformer.startListening()
 }
 

--- a/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
+++ b/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
@@ -10,16 +10,20 @@ import Backend
 
 func registerSubscribers() {
     BackendAPI.subscribe(listviewSubscriber)
+    BackendAPI.subscribe(detailsViewTransformer.stateObserver)
 
     startListening()
 }
 
 private func startListening() {
+    detailsViewTransformer.startListening()
 }
 
 private func stopListening() {
+    detailsViewTransformer.stopListening()
 }
 
 // MARK: Transformers
 
 let listviewSubscriber = ListViewTransformer()
+let detailsViewTransformer = DetailsViewTransformer()

--- a/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
+++ b/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
@@ -1,0 +1,25 @@
+//
+//  registerSubscribers.swift
+//  Mac-App
+//
+//  Created by Daniel GARCÍA on 03.05.20.
+//  Copyright © 2020 Acphut Werkstatt. All rights reserved.
+//
+
+import Backend
+
+func registerSubscribers() {
+    BackendAPI.subscribe(listviewSubscriber)
+
+    startListening()
+}
+
+private func startListening() {
+}
+
+private func stopListening() {
+}
+
+// MARK: Transformers
+
+let listviewSubscriber = ListViewTransformer()

--- a/Mac-App/Mac-App/StateObserver/StateObserver.swift
+++ b/Mac-App/Mac-App/StateObserver/StateObserver.swift
@@ -1,0 +1,24 @@
+//
+//  StateObserver.swift
+//  Mac-App
+//
+//  Created by Daniel GARCÍA on 03.05.20.
+//  Copyright © 2020 Acphut Werkstatt. All rights reserved.
+//
+
+import ReSwift
+import Backend
+
+final class StateObserver: StoreSubscriber {
+    typealias StoreSubscriberStateType = AppState
+
+    @Published
+    private(set) var currentState: AppState!
+
+    func newState(state: AppState) {
+        guard currentState != state else { return }
+
+        currentState = state
+    }
+}
+

--- a/Mac-App/Mac-App/StateObserver/StateObserver.swift
+++ b/Mac-App/Mac-App/StateObserver/StateObserver.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Acphut Werkstatt. All rights reserved.
 //
 
-import Backend
 import ReSwift
 
 final class StateObserver<State: StateType & Equatable>: StoreSubscriber {

--- a/Mac-App/Mac-App/StateObserver/StateObserver.swift
+++ b/Mac-App/Mac-App/StateObserver/StateObserver.swift
@@ -9,13 +9,13 @@
 import Backend
 import ReSwift
 
-final class StateObserver: StoreSubscriber {
-    typealias StoreSubscriberStateType = AppState
+final class StateObserver<State: StateType & Equatable>: StoreSubscriber {
+    typealias StoreSubscriberStateType = State
 
     @Published
-    private(set) var currentState: AppState!
+    private(set) var currentState: State!
 
-    func newState(state: AppState) {
+    func newState(state: State) {
         guard currentState != state else { return }
 
         currentState = state

--- a/Mac-App/Mac-App/StateObserver/StateObserver.swift
+++ b/Mac-App/Mac-App/StateObserver/StateObserver.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 Acphut Werkstatt. All rights reserved.
 //
 
-import ReSwift
 import Backend
+import ReSwift
 
 final class StateObserver: StoreSubscriber {
     typealias StoreSubscriberStateType = AppState
@@ -21,4 +21,3 @@ final class StateObserver: StoreSubscriber {
         currentState = state
     }
 }
-

--- a/Mac-App/Mac-App/StateObserver/StateObserver.swift
+++ b/Mac-App/Mac-App/StateObserver/StateObserver.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Acphut Werkstatt. All rights reserved.
 //
 
+import Combine
 import ReSwift
 
 final class StateObserver<State: StateType & Equatable>: StoreSubscriber {

--- a/Mac-App/Mac-App/Transformers/DetailsViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/DetailsViewTransformer.swift
@@ -20,7 +20,7 @@ final class DetailsViewTransformer {
         cancellable = stateObserver.$currentState.sink {
             [weak self] appState in
 
-            precondition(appState != nil, "State observer should always have an initial state provided by the Backed!")
+            precondition(appState != nil, "State observer should always have an initial state provided by the Backend!")
             self?.emitNewData(appState!)
         }
     }

--- a/Mac-App/Mac-App/Transformers/DetailsViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/DetailsViewTransformer.swift
@@ -17,7 +17,12 @@ final class DetailsViewTransformer {
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {
-        cancellable = stateObserver.$currentState.sink { [weak self] appState in self?.emitNewData(appState!) }
+        cancellable = stateObserver.$currentState.sink {
+            [weak self] appState in
+
+            precondition(appState != nil, "State observer should always have an initial state provided by the Backed!")
+            self?.emitNewData(appState!)
+        }
     }
 
     func stopListening() {

--- a/Mac-App/Mac-App/Transformers/DetailsViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/DetailsViewTransformer.swift
@@ -7,14 +7,23 @@
 //
 
 import Backend
+import Combine
 import Frontend
-import ReSwift
 
-final class DetailsViewTransformer: StoreSubscriber {
-    typealias StoreSubscriberStateType = AppState
+final class DetailsViewTransformer {
+    let stateObserver = StateObserver()
     private(set) var transformedData: ObservableData<ProjectFactsViewData.State> = .init(.initial)
+    private var cancellable: AnyCancellable = AnyCancellable {}
 
-    func newState(state: AppState) {
+    func startListening() {
+        cancellable = stateObserver.$currentState.sink { [weak self] appState in self?.emitNewState(appState!) }
+    }
+
+    func stopListening() {
+        cancellable.cancel()
+    }
+
+    private func emitNewState(_ state: AppState) {
         let viewData = mapAppStateToViewData(state)
 
         switch viewData {

--- a/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
@@ -20,7 +20,7 @@ final class ListViewTransformer {
         cancellable = stateObserver.$currentState.sink {
             [weak self] appState in
 
-            precondition(appState != nil, "State observer should always have an initial state provided by the Backed!")
+            precondition(appState != nil, "State observer should always have an initial state provided by the Backend!")
             self?.emitNewData(appState!)
         }
     }

--- a/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
@@ -17,7 +17,12 @@ final class ListViewTransformer {
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {
-        cancellable = stateObserver.$currentState.sink { [weak self] appState in self?.emitNewData(appState!) }
+        cancellable = stateObserver.$currentState.sink {
+            [weak self] appState in
+
+            precondition(appState != nil, "State observer should always have an initial state provided by the Backed!")
+            self?.emitNewData(appState!)
+        }
     }
 
     func stopListening() {

--- a/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
@@ -9,35 +9,44 @@
 import Backend
 import Combine
 import Frontend
+import ReSwift
 
 final class ListViewTransformer {
-    let stateObserver = StateObserver()
+    let stateObserver = StateObserver<DependencyTreeView.Data>()
     private(set) var transformedData: ObservableData<DependencyTreeView.State> = .init(.initial)
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {
-        cancellable = stateObserver.$currentState.sink { [weak self] appState in self?.emitNewState(appState!) }
+        cancellable = stateObserver.$currentState.sink { [weak self] appState in self?.emitNewData(appState!) }
     }
 
     func stopListening() {
         cancellable.cancel()
     }
 
-    private func emitNewState(_ newState: AppState) {
-        let viewData = mapAppStateToViewData(newState)
+    private func emitNewData(_ viewData: DependencyTreeView.Data) {
         if viewData.dependencies.isEmpty == false {
             transformedData.render(.success(viewData: viewData))
-        } else if let failure = newState.dependencyGraphState.failure {
+        } else if let failure = viewData.failure {
             transformedData.render(.failure(failure))
         }
     }
+}
 
-    private func mapAppStateToViewData(_ appState: AppState) -> DependencyTreeView.Data {
-        .init(dependencies: appState.dependencyGraphState.tree.map {
-            DependencyTreeView.Data.Dependency(
-                owner: $0.owner,
-                dependencies: $0.dependencies.map { String($0.name) }
-            )
-        })
+// MARK: - Mapper from AppState to subscriber state (view data for UI)
+
+extension DependencyTreeView.Data {
+    init(appState: AppState) {
+        self.init(
+            dependencies: appState.dependencyGraphState.tree.map {
+                DependencyTreeView.Data.Dependency(
+                    owner: $0.owner,
+                    dependencies: $0.dependencies.map { String($0.name) }
+                )
+            },
+            failure: appState.dependencyGraphState.failure
+        )
     }
 }
+
+extension DependencyTreeView.Data: StateType {}


### PR DESCRIPTION
With this PR I'm attempting to add some bare bones infrastructure for state updates.

The problems this attempt to solve are the following: 

1. **Code duplication:** Pretty much every transformer needs to make sure the new state is actually different from what it's already cached. Otherwise for every new AppState change every transformer gets informed, which is unnecessary & can lead to lots of overhead as the application grows
2. **Reuse State observer:** As of now, every transformer register itself to the `Backend` to get updates from the AppState. This approach is an opening for inconsistencies as there's nothing preventing every transformer from using a custom implementation. 
By introducing a generic entity, we ensure we get the correct updates while enforcing mapping from a the AppState to the desired data (view data to used to render views). Transformers should remain simple by simply mapping `Backend` constructs to `Frontend` ones. 
3. **Extends `Frontend` entities (ViewData).** By providing a constructor that takes the whole AppState but cherry-picks whatever is needed to render views. 

 @emrepun I think I will stick with this solution as the other involves inheritance & I prefer composing stuff instead of inheriting tons of magic. 