### PR TITLE
Script to bootstrap project

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Comment line above & uncomment line below for debugging
+# Print every command before executing it (set -x).
+#set -euxo pipefail
+
+
+if which accio >/dev/null; then
+    if which carthage >/dev/null; then
+        cd ../Mac-App/Backend
+        accio install
+    else
+        echo "Please install Carthage first"
+        echo "https://github.com/Carthage/Carthage"
+    fi
+else
+    echo "Please install Accio first"
+    echo "https://github.com/JamitLabs/Accio"
+fi


### PR DESCRIPTION
Quick & dirty script to bootstrap the project before compiling it. 

Seems like SPM in Xcode 12 will include a bunch of missing features that will potentially deprecate Accio usage. Until then, I will stick with it but will leave cloners install it on their own before executing this script. 