### PR TITLE
Feature - Project Details View

### DIFF
--- a/Mac-App/Frontend/Frontend.xcodeproj/project.pbxproj
+++ b/Mac-App/Frontend/Frontend.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A82DDE0F246E5822000259BF /* ActivityIndicator+LoadingDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82DDE0E246E5822000259BF /* ActivityIndicator+LoadingDescription.swift */; };
 		A88160DB2421073300CDB15A /* DependencyItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88160DA2421073300CDB15A /* DependencyItemView.swift */; };
 		A88160DD2421480E00CDB15A /* ListRowModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88160DC2421480E00CDB15A /* ListRowModifier.swift */; };
 		A8DF67612411639500D0DE02 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8DF67602411639500D0DE02 /* ActivityIndicator.swift */; };
@@ -34,6 +35,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A82DDE0E246E5822000259BF /* ActivityIndicator+LoadingDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ActivityIndicator+LoadingDescription.swift"; sourceTree = "<group>"; };
 		A88160DA2421073300CDB15A /* DependencyItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyItemView.swift; sourceTree = "<group>"; };
 		A88160DC2421480E00CDB15A /* ListRowModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListRowModifier.swift; sourceTree = "<group>"; };
 		A8DF67602411639500D0DE02 /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
@@ -77,6 +79,7 @@
 			children = (
 				A8DF67602411639500D0DE02 /* ActivityIndicator.swift */,
 				A88160DC2421480E00CDB15A /* ListRowModifier.swift */,
+				A82DDE0E246E5822000259BF /* ActivityIndicator+LoadingDescription.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -319,6 +322,7 @@
 				A88160DB2421073300CDB15A /* DependencyItemView.swift in Sources */,
 				A8FECAA92431086D0028CC64 /* ProjectDetails.swift in Sources */,
 				A8FECAA22429ED1A0028CC64 /* MainSplitViewController.swift in Sources */,
+				A82DDE0F246E5822000259BF /* ActivityIndicator+LoadingDescription.swift in Sources */,
 				A8FECAA72430BCAE0028CC64 /* DetailsView.swift in Sources */,
 				A8F2526824029B6500CD12DE /* DependencyTree.swift in Sources */,
 				A8DF67642412D9AE00D0DE02 /* InputView.swift in Sources */,

--- a/Mac-App/Frontend/Frontend.xcodeproj/project.pbxproj
+++ b/Mac-App/Frontend/Frontend.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A82DDE0F246E5822000259BF /* ActivityIndicator+LoadingDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82DDE0E246E5822000259BF /* ActivityIndicator+LoadingDescription.swift */; };
+		A86ED71C24767B300008B604 /* PlainList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86ED71B24767B300008B604 /* PlainList.swift */; };
 		A88160DB2421073300CDB15A /* DependencyItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88160DA2421073300CDB15A /* DependencyItemView.swift */; };
 		A88160DD2421480E00CDB15A /* ListRowModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88160DC2421480E00CDB15A /* ListRowModifier.swift */; };
 		A8DF67612411639500D0DE02 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8DF67602411639500D0DE02 /* ActivityIndicator.swift */; };
@@ -36,6 +37,7 @@
 
 /* Begin PBXFileReference section */
 		A82DDE0E246E5822000259BF /* ActivityIndicator+LoadingDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ActivityIndicator+LoadingDescription.swift"; sourceTree = "<group>"; };
+		A86ED71B24767B300008B604 /* PlainList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainList.swift; sourceTree = "<group>"; };
 		A88160DA2421073300CDB15A /* DependencyItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyItemView.swift; sourceTree = "<group>"; };
 		A88160DC2421480E00CDB15A /* ListRowModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListRowModifier.swift; sourceTree = "<group>"; };
 		A8DF67602411639500D0DE02 /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 				A8DF67602411639500D0DE02 /* ActivityIndicator.swift */,
 				A88160DC2421480E00CDB15A /* ListRowModifier.swift */,
 				A82DDE0E246E5822000259BF /* ActivityIndicator+LoadingDescription.swift */,
+				A86ED71B24767B300008B604 /* PlainList.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -318,6 +321,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A86ED71C24767B300008B604 /* PlainList.swift in Sources */,
 				A8DF67612411639500D0DE02 /* ActivityIndicator.swift in Sources */,
 				A88160DB2421073300CDB15A /* DependencyItemView.swift in Sources */,
 				A8FECAA92431086D0028CC64 /* ProjectDetails.swift in Sources */,

--- a/Mac-App/Frontend/Frontend.xcodeproj/project.pbxproj
+++ b/Mac-App/Frontend/Frontend.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		A8F2525223FF0B5000CD12DE /* FrontendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F2525123FF0B5000CD12DE /* FrontendTests.swift */; };
 		A8F2525423FF0B5000CD12DE /* Frontend.h in Headers */ = {isa = PBXBuildFile; fileRef = A8F2524623FF0B5000CD12DE /* Frontend.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A8F2525E23FF0BF300CD12DE /* ExpandableListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F2525D23FF0BF300CD12DE /* ExpandableListView.swift */; };
-		A8F2526424029A2400CD12DE /* ObservableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F2526324029A2400CD12DE /* ObservableData.swift */; };
+		A8F2526424029A2400CD12DE /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F2526324029A2400CD12DE /* Observable.swift */; };
 		A8F2526824029B6500CD12DE /* DependencyTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F2526724029B6500CD12DE /* DependencyTree.swift */; };
 		A8FECAA22429ED1A0028CC64 /* MainSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FECAA12429ED1A0028CC64 /* MainSplitViewController.swift */; };
 		A8FECAA4243096650028CC64 /* MainSplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FECAA3243096650028CC64 /* MainSplitView.swift */; };
@@ -47,7 +47,7 @@
 		A8F2525123FF0B5000CD12DE /* FrontendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontendTests.swift; sourceTree = "<group>"; };
 		A8F2525323FF0B5000CD12DE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A8F2525D23FF0BF300CD12DE /* ExpandableListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableListView.swift; sourceTree = "<group>"; };
-		A8F2526324029A2400CD12DE /* ObservableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableData.swift; sourceTree = "<group>"; };
+		A8F2526324029A2400CD12DE /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		A8F2526724029B6500CD12DE /* DependencyTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyTree.swift; sourceTree = "<group>"; };
 		A8FECAA12429ED1A0028CC64 /* MainSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSplitViewController.swift; sourceTree = "<group>"; };
 		A8FECAA3243096650028CC64 /* MainSplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSplitView.swift; sourceTree = "<group>"; };
@@ -134,7 +134,7 @@
 		A8F25262240299FD00CD12DE /* ObservableData */ = {
 			isa = PBXGroup;
 			children = (
-				A8F2526324029A2400CD12DE /* ObservableData.swift */,
+				A8F2526324029A2400CD12DE /* Observable.swift */,
 			);
 			path = ObservableData;
 			sourceTree = "<group>";
@@ -327,7 +327,7 @@
 				A8F2526824029B6500CD12DE /* DependencyTree.swift in Sources */,
 				A8DF67642412D9AE00D0DE02 /* InputView.swift in Sources */,
 				A88160DD2421480E00CDB15A /* ListRowModifier.swift in Sources */,
-				A8F2526424029A2400CD12DE /* ObservableData.swift in Sources */,
+				A8F2526424029A2400CD12DE /* Observable.swift in Sources */,
 				A8F2525E23FF0BF300CD12DE /* ExpandableListView.swift in Sources */,
 				A8FECAA4243096650028CC64 /* MainSplitView.swift in Sources */,
 			);

--- a/Mac-App/Frontend/Frontend/ObservableData/Observable.swift
+++ b/Mac-App/Frontend/Frontend/ObservableData/Observable.swift
@@ -14,26 +14,26 @@ import Foundation
 /// a `@Published` property
 /// The publisher is part of the generic class as protocols cannot have property wrappers ☹️
 public protocol ViewInput {
-    associatedtype Data: Equatable
+    associatedtype Input: Equatable
 
-    init(_ data: Data)
-    func render(_ newData: Data)
+    init(_ input: Input)
+    func update(to newInput: Input)
 }
 
 open class Observable<T: Equatable>: ViewInput, ObservableObject {
-    public typealias Data = T
+    public typealias Input = T
 
-    @Published private(set) var data: T
+    @Published private(set) var input: T
 
-    public required init(_ data: T) {
-        self.data = data
+    public required init(_ input: T) {
+        self.input = input
     }
 
     /// This triggers an UI update  for any view defining this class as a `@ObservedObject`
 
-    public func render(_ newData: T) {
+    public func update(to newInput: T) {
         DispatchQueue.main.async {
-            self.data = newData
+            self.input = newInput
         }
     }
 }

--- a/Mac-App/Frontend/Frontend/ObservableData/Observable.swift
+++ b/Mac-App/Frontend/Frontend/ObservableData/Observable.swift
@@ -20,7 +20,7 @@ public protocol ViewInput {
     func render(_ newData: Data)
 }
 
-open class ObservableData<T: Equatable>: ViewInput, ObservableObject {
+open class Observable<T: Equatable>: ViewInput, ObservableObject {
     public typealias Data = T
 
     @Published private(set) var data: T

--- a/Mac-App/Frontend/Frontend/ViewData/ProjectDetails.swift
+++ b/Mac-App/Frontend/Frontend/ViewData/ProjectDetails.swift
@@ -27,9 +27,9 @@ public enum ProjectDetails {
         }
     }
 
-    // MARK: - View State
+    // MARK: - View Status
 
-    public enum State: Equatable {
+    public enum Status: Equatable {
         case initial
         case failure(_ failure: String)
         case success(viewData: Data)

--- a/Mac-App/Frontend/Frontend/ViewData/ProjectDetails.swift
+++ b/Mac-App/Frontend/Frontend/ViewData/ProjectDetails.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 public enum ProjectDetails {
-    // MARK: - View Data
+    // MARK: - View State
 
-    public struct Data: Equatable {
+    public struct State: Equatable {
         public let heaviestDependency: String
         public let totalDependenciesFound: Int
         public let paths: [URL]
@@ -32,6 +32,6 @@ public enum ProjectDetails {
     public enum Status: Equatable {
         case initial
         case failure(_ failure: String)
-        case success(viewData: Data)
+        case success(viewData: State)
     }
 }

--- a/Mac-App/Frontend/Frontend/ViewData/ProjectDetails.swift
+++ b/Mac-App/Frontend/Frontend/ViewData/ProjectDetails.swift
@@ -35,6 +35,6 @@ public enum ProjectDetails {
     public enum Status: Equatable {
         case initial
         case failure(_ failure: String)
-        case success(viewData: State)
+        case success(state: State)
     }
 }

--- a/Mac-App/Frontend/Frontend/ViewData/ProjectDetails.swift
+++ b/Mac-App/Frontend/Frontend/ViewData/ProjectDetails.swift
@@ -15,15 +15,18 @@ public enum ProjectDetails {
         public let heaviestDependency: String
         public let totalDependenciesFound: Int
         public let paths: [URL]
+        public var failure: String?
 
         public init(
             heaviestDependency: String,
             totalDependenciesFound: Int,
-            paths: [URL]
+            paths: [URL],
+            failure: String?
         ) {
             self.heaviestDependency = heaviestDependency
             self.totalDependenciesFound = totalDependenciesFound
             self.paths = paths
+            self.failure = failure
         }
     }
 

--- a/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator+LoadingDescription.swift
+++ b/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator+LoadingDescription.swift
@@ -1,0 +1,25 @@
+//
+//  ActivityIndicator+LoadingDescription.swift
+//  Frontend
+//
+//  Created by Daniel GARCÍA on 15.05.20.
+//  Copyright © 2020 Acphut Werkstatt. All rights reserved.
+//
+
+import SwiftUI
+
+struct LoadingView: View {
+    let title: String
+    @State var isloading: Bool = true
+
+    var body: some View {
+        VStack {
+            ActivityIndicator(isAnimating: $isloading, style: .spinning)
+                .padding()
+            Text("\(title)")
+                .bold()
+                .foregroundColor(.gray)
+                .padding()
+        }
+    }
+}

--- a/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator+LoadingDescription.swift
+++ b/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator+LoadingDescription.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct LoadingView: View {
     let title: String
+    let titleColor: Color
     @State var isloading: Bool = true
 
     var body: some View {
@@ -18,7 +19,7 @@ struct LoadingView: View {
                 .padding()
             Text("\(title)")
                 .bold()
-                .foregroundColor(.gray)
+                .foregroundColor(titleColor)
                 .padding()
         }
     }

--- a/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator.swift
+++ b/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ActivityIndicator: NSViewRepresentable {
     typealias NSViewType = NSProgressIndicator
 
-    @Binding var isAnimating: Bool
+    @State var isAnimating: Bool
     let style: NSProgressIndicator.Style
 
     func makeNSView(context _: NSViewRepresentableContext<ActivityIndicator>) -> NSProgressIndicator {

--- a/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator.swift
+++ b/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ActivityIndicator: NSViewRepresentable {
     typealias NSViewType = NSProgressIndicator
 
-    @State var isAnimating: Bool
+    @Binding var isAnimating: Bool
     let style: NSProgressIndicator.Style
 
     func makeNSView(context _: NSViewRepresentableContext<ActivityIndicator>) -> NSProgressIndicator {

--- a/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator.swift
+++ b/Mac-App/Frontend/Frontend/Views/Common/ActivityIndicator.swift
@@ -1,3 +1,11 @@
+//
+//  ActivityIndicator.swift
+//  Frontend
+//
+//  Created by Daniel GARCÍA on 05.03.20.
+//  Copyright © 2020 Acphut Werkstatt. All rights reserved.
+//
+
 import SwiftUI
 
 struct ActivityIndicator: NSViewRepresentable {

--- a/Mac-App/Frontend/Frontend/Views/Common/ListRowModifier.swift
+++ b/Mac-App/Frontend/Frontend/Views/Common/ListRowModifier.swift
@@ -1,3 +1,11 @@
+//
+//  ListRowModifier.swift
+//  Frontend
+//
+//  Created by Daniel GARCÍA on 17.03.20.
+//  Copyright © 2020 Acphut Werkstatt. All rights reserved.
+//
+
 import SwiftUI
 
 struct ListRowModifier: ViewModifier {

--- a/Mac-App/Frontend/Frontend/Views/Common/PlainList.swift
+++ b/Mac-App/Frontend/Frontend/Views/Common/PlainList.swift
@@ -1,0 +1,25 @@
+//
+//  PlainList.swift
+//  Frontend
+//
+//  Created by Daniel GARCÍA on 21.05.20.
+//  Copyright © 2020 Acphut Werkstatt. All rights reserved.
+//
+
+import SwiftUI
+
+struct PlainList: View {
+    let title: [String]
+    let itemsColor: Color
+
+    public var body: some View {
+        List {
+            ForEach(title, id: \.id) { title in
+                Text(title)
+                    .font(.caption)
+                    .italic()
+                    .foregroundColor(self.itemsColor)
+            }
+        }
+    }
+}

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -27,7 +27,6 @@ public struct DetailsView: View {
         case let .success(state: viewData):
             return AnyView(
                 VStack {
-                    Spacer().frame(minHeight: 16, maxHeight: 36)
                     Text("Heaviest dependency: ")
                         .foregroundColor(.yellow)
                         .font(.system(.headline))

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -16,7 +16,7 @@ public struct DetailsView: View {
     }
 
     public var body: some View {
-        switch projectDetailsState.data {
+        switch projectDetailsState.input {
         case .initial:
             return AnyView(
                 LoadingView(

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -16,7 +16,36 @@ public struct DetailsView: View {
     }
 
     public var body: some View {
-        Text("Options will go here")
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        switch projectDetailsState.data {
+        case .initial:
+            return AnyView(
+                LoadingView(
+                    title: "Finding relevant stats...",
+                    isloading: true
+                )
+            )
+        case let .success(viewData: viewData):
+            return AnyView(
+                VStack {
+                    Text("Heaviest dependency - \(viewData.heaviestDependency)")
+                        .underline()
+                        .foregroundColor(.red)
+                        .font(.system(.headline))
+                    Text("Total dependencies found: \(viewData.totalDependenciesFound)")
+                        .bold()
+                        .foregroundColor(.white)
+                        .font(.system(.body))
+                    Text("Files scanned: \(viewData.paths.count)")
+                        .bold()
+                        .foregroundColor(.white)
+                        .font(.system(.body))
+                }.frame(maxWidth: .infinity, maxHeight: .infinity)
+            )
+        case let .failure(errorMessage):
+            return
+                AnyView(
+                    Text("Something went wrong! - \(errorMessage)")
+                )
+        }
     }
 }

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -57,7 +57,8 @@ public struct DetailsView: View {
         case let .failure(errorMessage):
             return
                 AnyView(
-                    Text("Something went wrong! - \(errorMessage)")
+                    Text(errorMessage)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 )
         }
     }

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -9,14 +9,14 @@
 import SwiftUI
 
 public struct DetailsView: View {
-    @ObservedObject private var projectDetailsState: Observable<ProjectDetails.Status>
+    @ObservedObject private var projectDetailsStatus: Observable<ProjectDetails.Status>
 
-    public init(projectDetailsState: Observable<ProjectDetails.Status>) {
-        self.projectDetailsState = projectDetailsState
+    public init(projectDetailsStatus: Observable<ProjectDetails.Status>) {
+        self.projectDetailsStatus = projectDetailsStatus
     }
 
     public var body: some View {
-        switch projectDetailsState.input {
+        switch projectDetailsStatus.input {
         case .initial:
             return AnyView(
                 LoadingView(

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -21,6 +21,7 @@ public struct DetailsView: View {
             return AnyView(
                 LoadingView(
                     title: "Finding relevant stats...",
+                    titleColor: .gray,
                     isloading: true
                 )
             )

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -24,7 +24,7 @@ public struct DetailsView: View {
                     isloading: true
                 )
             )
-        case let .success(viewData: viewData):
+        case let .success(state: viewData):
             return AnyView(
                 VStack {
                     Spacer().frame(minHeight: 16, maxHeight: 36)

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -46,7 +46,7 @@ public struct DetailsView: View {
                         .font(.system(.body))
                     Spacer().frame(minHeight: 16, maxHeight: 36)
                 }
-                .padding(EdgeInsets(top: 45, leading: 4, bottom: 45, trailing: 4))
+                .padding(EdgeInsets(top: 16, leading: 4, bottom: 16, trailing: 4))
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             )
         case let .failure(errorMessage):

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -45,6 +45,10 @@ public struct DetailsView: View {
                         .foregroundColor(.white)
                         .font(.system(.body))
                     Spacer().frame(minHeight: 16, maxHeight: 36)
+                    PlainList(
+                        title: viewData.paths.map { String($0.absoluteString) },
+                        itemsColor: .yellow
+                    )
                 }
                 .padding(EdgeInsets(top: 16, leading: 4, bottom: 16, trailing: 4))
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -9,6 +9,12 @@
 import SwiftUI
 
 public struct DetailsView: View {
+    @ObservedObject private var projectDetailsState: ObservableData<ProjectDetails.State>
+
+    public init(projectDetailsState: ObservableData<ProjectDetails.State>) {
+        self.projectDetailsState = projectDetailsState
+    }
+
     public var body: some View {
         Text("Options will go here")
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -25,29 +25,29 @@ public struct DetailsView: View {
                     isloading: true
                 )
             )
-        case let .success(state: viewData):
+        case let .success(state: state):
             return AnyView(
                 VStack {
                     Text("Heaviest dependency: ")
                         .foregroundColor(.yellow)
                         .font(.system(.headline))
-                    Text(viewData.heaviestDependency)
+                    Text(state.heaviestDependency)
                         .underline()
                         .font(.system(.subheadline))
                         .foregroundColor(.red)
                     Spacer().frame(minHeight: 16, maxHeight: 36)
-                    Text("Total dependencies found: \(viewData.totalDependenciesFound)")
+                    Text("Total dependencies found: \(state.totalDependenciesFound)")
                         .bold()
                         .foregroundColor(.white)
                         .font(.system(.body))
                     Spacer().frame(minHeight: 16, maxHeight: 36)
-                    Text("Files scanned: \(viewData.paths.count)")
+                    Text("Files scanned: \(state.paths.count)")
                         .bold()
                         .foregroundColor(.white)
                         .font(.system(.body))
                     Spacer().frame(minHeight: 16, maxHeight: 36)
                     PlainList(
-                        title: viewData.paths.map { String($0.absoluteString) },
+                        title: state.paths.map { String($0.absoluteString) },
                         itemsColor: .yellow
                     )
                 }

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -9,9 +9,9 @@
 import SwiftUI
 
 public struct DetailsView: View {
-    @ObservedObject private var projectDetailsState: ObservableData<ProjectDetails.State>
+    @ObservedObject private var projectDetailsState: Observable<ProjectDetails.State>
 
-    public init(projectDetailsState: ObservableData<ProjectDetails.State>) {
+    public init(projectDetailsState: Observable<ProjectDetails.State>) {
         self.projectDetailsState = projectDetailsState
     }
 

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -27,19 +27,28 @@ public struct DetailsView: View {
         case let .success(viewData: viewData):
             return AnyView(
                 VStack {
-                    Text("Heaviest dependency - \(viewData.heaviestDependency)")
-                        .underline()
-                        .foregroundColor(.red)
+                    Spacer().frame(minHeight: 16, maxHeight: 36)
+                    Text("Heaviest dependency: ")
+                        .foregroundColor(.yellow)
                         .font(.system(.headline))
+                    Text(viewData.heaviestDependency)
+                        .underline()
+                        .font(.system(.subheadline))
+                        .foregroundColor(.red)
+                    Spacer().frame(minHeight: 16, maxHeight: 36)
                     Text("Total dependencies found: \(viewData.totalDependenciesFound)")
                         .bold()
                         .foregroundColor(.white)
                         .font(.system(.body))
+                    Spacer().frame(minHeight: 16, maxHeight: 36)
                     Text("Files scanned: \(viewData.paths.count)")
                         .bold()
                         .foregroundColor(.white)
                         .font(.system(.body))
-                }.frame(maxWidth: .infinity, maxHeight: .infinity)
+                    Spacer().frame(minHeight: 16, maxHeight: 36)
+                }
+                .padding(EdgeInsets(top: 45, leading: 4, bottom: 45, trailing: 4))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             )
         case let .failure(errorMessage):
             return

--- a/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
+++ b/Mac-App/Frontend/Frontend/Views/DetailsView/DetailsView.swift
@@ -9,9 +9,9 @@
 import SwiftUI
 
 public struct DetailsView: View {
-    @ObservedObject private var projectDetailsState: Observable<ProjectDetails.State>
+    @ObservedObject private var projectDetailsState: Observable<ProjectDetails.Status>
 
-    public init(projectDetailsState: Observable<ProjectDetails.State>) {
+    public init(projectDetailsState: Observable<ProjectDetails.Status>) {
         self.projectDetailsState = projectDetailsState
     }
 

--- a/Mac-App/Frontend/Frontend/Views/ExpandableList/DependencyItemView.swift
+++ b/Mac-App/Frontend/Frontend/Views/ExpandableList/DependencyItemView.swift
@@ -1,3 +1,11 @@
+//
+//  DependencyItemView.swift
+//  Frontend
+//
+//  Created by Daniel GARCÍA on 17.03.20.
+//  Copyright © 2020 Acphut Werkstatt. All rights reserved.
+//
+
 import SwiftUI
 
 struct DependencyItemView: View {

--- a/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
+++ b/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
@@ -17,7 +17,7 @@ public struct ExpandableListView: View {
     }
 
     public var body: some View {
-        switch dependencyTreeState.data {
+        switch dependencyTreeState.input {
         case .initial:
             return AnyView(
                 LoadingView(

--- a/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
+++ b/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
@@ -20,14 +20,10 @@ public struct ExpandableListView: View {
         switch dependencyTreeState.data {
         case .initial:
             return AnyView(
-                VStack {
-                    ActivityIndicator(isAnimating: true, style: .spinning)
-                        .padding()
-                    Text("Processing build files...")
-                        .bold()
-                        .foregroundColor(.gray)
-                        .padding()
-                }.frame(maxWidth: .infinity, maxHeight: .infinity)
+                LoadingView(
+                    title: "Processing build files...",
+                    isloading: true
+                ).frame(maxWidth: .infinity, maxHeight: .infinity)
             )
         case let .success(viewData: data):
             return AnyView(VStack(alignment: .leading, spacing: 8) {

--- a/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
+++ b/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
@@ -9,10 +9,10 @@
 import SwiftUI
 
 public struct ExpandableListView: View {
-    @ObservedObject private var dependencyTreeState: ObservableData<DependencyTree.State>
+    @ObservedObject private var dependencyTreeState: Observable<DependencyTree.State>
     @State private var selection: Set<DependencyTree.Data.Dependency> = []
 
-    public init(dependencyTreeState: ObservableData<DependencyTree.State>) {
+    public init(dependencyTreeState: Observable<DependencyTree.State>) {
         self.dependencyTreeState = dependencyTreeState
     }
 

--- a/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
+++ b/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
@@ -9,15 +9,15 @@
 import SwiftUI
 
 public struct ExpandableListView: View {
-    @ObservedObject private var viewData: ObservableData<DependencyTree.State>
+    @ObservedObject private var dependencyTreeState: ObservableData<DependencyTree.State>
     @State private var selection: Set<DependencyTree.Data.Dependency> = []
 
-    public init(viewData: ObservableData<DependencyTree.State>) {
-        self.viewData = viewData
+    public init(dependencyTreeState: ObservableData<DependencyTree.State>) {
+        self.dependencyTreeState = dependencyTreeState
     }
 
     public var body: some View {
-        switch viewData.data {
+        switch dependencyTreeState.data {
         case .initial:
             return AnyView(
                 VStack {

--- a/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
+++ b/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
@@ -22,6 +22,7 @@ public struct ExpandableListView: View {
             return AnyView(
                 LoadingView(
                     title: "Processing build files...",
+                    titleColor: .gray,
                     isloading: true
                 ).frame(maxWidth: .infinity, maxHeight: .infinity)
             )

--- a/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
+++ b/Mac-App/Frontend/Frontend/Views/ExpandableList/ExpandableListView.swift
@@ -21,7 +21,7 @@ public struct ExpandableListView: View {
         case .initial:
             return AnyView(
                 VStack {
-                    ActivityIndicator(isAnimating: Binding<Bool>.constant(true), style: .spinning)
+                    ActivityIndicator(isAnimating: true, style: .spinning)
                         .padding()
                     Text("Processing build files...")
                         .bold()

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
@@ -10,11 +10,11 @@ import SwiftUI
 
 public struct MainSplitView: View {
     private var dependencyTreeState: Observable<DependencyTree.State>
-    private var projectDetailsState: Observable<ProjectDetails.State>
+    private var projectDetailsState: Observable<ProjectDetails.Status>
 
     public init(
         dependencyTreeState: Observable<DependencyTree.State>,
-        projectDetailsState: Observable<ProjectDetails.State>
+        projectDetailsState: Observable<ProjectDetails.Status>
     ) {
         self.dependencyTreeState = dependencyTreeState
         self.projectDetailsState = projectDetailsState

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
@@ -9,12 +9,12 @@
 import SwiftUI
 
 public struct MainSplitView: View {
-    private var viewData: ObservableData<DependencyTree.State>
-    public init(viewData: ObservableData<DependencyTree.State>) {
-        self.viewData = viewData
+    private var dependencyTreeState: ObservableData<DependencyTree.State>
+    public init(dependencyTreeState: ObservableData<DependencyTree.State>) {
+        self.dependencyTreeState = dependencyTreeState
     }
 
     public var body: some View {
-        MainSplitViewController(viewData: viewData)
+        MainSplitViewController(dependencyTreeState: dependencyTreeState)
     }
 }

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
@@ -9,12 +9,12 @@
 import SwiftUI
 
 public struct MainSplitView: View {
-    private var dependencyTreeState: ObservableData<DependencyTree.State>
-    private var projectDetailsState: ObservableData<ProjectDetails.State>
+    private var dependencyTreeState: Observable<DependencyTree.State>
+    private var projectDetailsState: Observable<ProjectDetails.State>
 
     public init(
-        dependencyTreeState: ObservableData<DependencyTree.State>,
-        projectDetailsState: ObservableData<ProjectDetails.State>
+        dependencyTreeState: Observable<DependencyTree.State>,
+        projectDetailsState: Observable<ProjectDetails.State>
     ) {
         self.dependencyTreeState = dependencyTreeState
         self.projectDetailsState = projectDetailsState

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
@@ -10,11 +10,20 @@ import SwiftUI
 
 public struct MainSplitView: View {
     private var dependencyTreeState: ObservableData<DependencyTree.State>
-    public init(dependencyTreeState: ObservableData<DependencyTree.State>) {
+    private var projectDetailsState: ObservableData<ProjectDetails.State>
+
+    public init(
+        dependencyTreeState: ObservableData<DependencyTree.State>,
+        projectDetailsState: ObservableData<ProjectDetails.State>
+    ) {
         self.dependencyTreeState = dependencyTreeState
+        self.projectDetailsState = projectDetailsState
     }
 
     public var body: some View {
-        MainSplitViewController(dependencyTreeState: dependencyTreeState)
+        MainSplitViewController(
+            dependencyTreeState: dependencyTreeState,
+            projectDetailsState: projectDetailsState
+        )
     }
 }

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitView.swift
@@ -10,20 +10,20 @@ import SwiftUI
 
 public struct MainSplitView: View {
     private var dependencyTreeState: Observable<DependencyTree.State>
-    private var projectDetailsState: Observable<ProjectDetails.Status>
+    private var projectDetailsStatus: Observable<ProjectDetails.Status>
 
     public init(
         dependencyTreeState: Observable<DependencyTree.State>,
-        projectDetailsState: Observable<ProjectDetails.Status>
+        projectDetailsStatus: Observable<ProjectDetails.Status>
     ) {
         self.dependencyTreeState = dependencyTreeState
-        self.projectDetailsState = projectDetailsState
+        self.projectDetailsStatus = projectDetailsStatus
     }
 
     public var body: some View {
         MainSplitViewController(
             dependencyTreeState: dependencyTreeState,
-            projectDetailsState: projectDetailsState
+            projectDetailsStatus: projectDetailsStatus
         )
     }
 }

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
@@ -11,12 +11,12 @@ import SwiftUI
 struct MainSplitViewController: NSViewControllerRepresentable {
     typealias NSViewControllerType = NSSplitViewController
 
-    private var dependencyTreeState: ObservableData<DependencyTree.State>
-    private var projectDetailsState: ObservableData<ProjectDetails.State>
+    private var dependencyTreeState: Observable<DependencyTree.State>
+    private var projectDetailsState: Observable<ProjectDetails.State>
 
     public init(
-        dependencyTreeState: ObservableData<DependencyTree.State>,
-        projectDetailsState: ObservableData<ProjectDetails.State>
+        dependencyTreeState: Observable<DependencyTree.State>,
+        projectDetailsState: Observable<ProjectDetails.State>
     ) {
         self.dependencyTreeState = dependencyTreeState
         self.projectDetailsState = projectDetailsState
@@ -37,8 +37,8 @@ struct MainSplitViewController: NSViewControllerRepresentable {
 // MARK: - Factory functions
 
 private func makeSplitViewController(
-    using dependencyTreeState: ObservableData<DependencyTree.State>,
-    projectDetailsState: ObservableData<ProjectDetails.State>
+    using dependencyTreeState: Observable<DependencyTree.State>,
+    projectDetailsState: Observable<ProjectDetails.State>
 ) -> NSSplitViewController {
     let splitViewController = NSSplitViewController()
     splitViewController.addSplitViewItem(makeDetailsView(using: projectDetailsState))
@@ -53,7 +53,7 @@ private func makeSplitViewController(
 }
 
 private func makeDetailsView(
-    using projectDetailsState: ObservableData<ProjectDetails.State>
+    using projectDetailsState: Observable<ProjectDetails.State>
 ) -> NSSplitViewItem {
     let hostingController = NSHostingController(rootView: DetailsView(projectDetailsState: projectDetailsState))
     let splitViewItem = NSSplitViewItem(viewController: hostingController)
@@ -64,7 +64,7 @@ private func makeDetailsView(
 }
 
 private func makeExpandableList(
-    using dependencyTreeState: ObservableData<DependencyTree.State>
+    using dependencyTreeState: Observable<DependencyTree.State>
 ) -> NSSplitViewItem {
     let hostingController = NSHostingController(
         rootView: ExpandableListView(dependencyTreeState: dependencyTreeState)

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
@@ -12,14 +12,20 @@ struct MainSplitViewController: NSViewControllerRepresentable {
     typealias NSViewControllerType = NSSplitViewController
 
     private var dependencyTreeState: ObservableData<DependencyTree.State>
-    public init(dependencyTreeState: ObservableData<DependencyTree.State>) {
+    private var projectDetailsState: ObservableData<ProjectDetails.State>
+
+    public init(
+        dependencyTreeState: ObservableData<DependencyTree.State>,
+        projectDetailsState: ObservableData<ProjectDetails.State>
+    ) {
         self.dependencyTreeState = dependencyTreeState
+        self.projectDetailsState = projectDetailsState
     }
 
     func makeNSViewController(
         context _: NSViewControllerRepresentableContext<MainSplitViewController>
     ) -> NSSplitViewController {
-        makeSplitViewController(using: dependencyTreeState)
+        makeSplitViewController(using: dependencyTreeState, projectDetailsState: projectDetailsState)
     }
 
     func updateNSViewController(
@@ -31,11 +37,11 @@ struct MainSplitViewController: NSViewControllerRepresentable {
 // MARK: - Helpers
 
 private func makeSplitViewController(
-    using dependencyTreeState: ObservableData<DependencyTree.State>
+    using dependencyTreeState: ObservableData<DependencyTree.State>,
+    projectDetailsState: ObservableData<ProjectDetails.State>
 ) -> NSSplitViewController {
-
     let splitViewController = NSSplitViewController()
-    splitViewController.addSplitViewItem(makeDetailsView())
+    splitViewController.addSplitViewItem(makeDetailsView(using: projectDetailsState))
     splitViewController.addSplitViewItem(makeExpandableList(using: dependencyTreeState))
 
     let splitView = NSSplitView()
@@ -46,8 +52,10 @@ private func makeSplitViewController(
     return splitViewController
 }
 
-private func makeDetailsView() -> NSSplitViewItem {
-    let hostingController = NSHostingController(rootView: DetailsView())
+private func makeDetailsView(
+    using projectDetailsState: ObservableData<ProjectDetails.State>
+) -> NSSplitViewItem {
+    let hostingController = NSHostingController(rootView: DetailsView(projectDetailsState: projectDetailsState))
     let splitViewItem = NSSplitViewItem(viewController: hostingController)
     splitViewItem.holdingPriority = .defaultHigh
     splitViewItem.minimumThickness = 120
@@ -58,7 +66,6 @@ private func makeDetailsView() -> NSSplitViewItem {
 private func makeExpandableList(
     using dependencyTreeState: ObservableData<DependencyTree.State>
 ) -> NSSplitViewItem {
-
     let hostingController = NSHostingController(
         rootView: ExpandableListView(dependencyTreeState: dependencyTreeState)
     )

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
@@ -34,7 +34,7 @@ struct MainSplitViewController: NSViewControllerRepresentable {
     ) {}
 }
 
-// MARK: - Helpers
+// MARK: - Factory functions
 
 private func makeSplitViewController(
     using dependencyTreeState: ObservableData<DependencyTree.State>,

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
@@ -19,7 +19,7 @@ struct MainSplitViewController: NSViewControllerRepresentable {
     func makeNSViewController(
         context _: NSViewControllerRepresentableContext<MainSplitViewController>
     ) -> NSSplitViewController {
-        buildSplitViewController(using: dependencyTreeState)
+        makeSplitViewController(using: dependencyTreeState)
     }
 
     func updateNSViewController(
@@ -30,13 +30,13 @@ struct MainSplitViewController: NSViewControllerRepresentable {
 
 // MARK: - Helpers
 
-private func buildSplitViewController(
+private func makeSplitViewController(
     using dependencyTreeState: ObservableData<DependencyTree.State>
 ) -> NSSplitViewController {
 
     let splitViewController = NSSplitViewController()
-    splitViewController.addSplitViewItem(buildDetailsViewItem())
-    splitViewController.addSplitViewItem(buildContentViewItem(using: dependencyTreeState))
+    splitViewController.addSplitViewItem(makeDetailsView())
+    splitViewController.addSplitViewItem(makeExpandableList(using: dependencyTreeState))
 
     let splitView = NSSplitView()
     splitView.isVertical = true
@@ -46,7 +46,7 @@ private func buildSplitViewController(
     return splitViewController
 }
 
-private func buildDetailsViewItem() -> NSSplitViewItem {
+private func makeDetailsView() -> NSSplitViewItem {
     let hostingController = NSHostingController(rootView: DetailsView())
     let splitViewItem = NSSplitViewItem(viewController: hostingController)
     splitViewItem.holdingPriority = .defaultHigh
@@ -55,7 +55,7 @@ private func buildDetailsViewItem() -> NSSplitViewItem {
     return splitViewItem
 }
 
-private func buildContentViewItem(
+private func makeExpandableList(
     using dependencyTreeState: ObservableData<DependencyTree.State>
 ) -> NSSplitViewItem {
 

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
@@ -12,20 +12,20 @@ struct MainSplitViewController: NSViewControllerRepresentable {
     typealias NSViewControllerType = NSSplitViewController
 
     private var dependencyTreeState: Observable<DependencyTree.State>
-    private var projectDetailsState: Observable<ProjectDetails.Status>
+    private var projectDetailsStatus: Observable<ProjectDetails.Status>
 
     public init(
         dependencyTreeState: Observable<DependencyTree.State>,
-        projectDetailsState: Observable<ProjectDetails.Status>
+        projectDetailsStatus: Observable<ProjectDetails.Status>
     ) {
         self.dependencyTreeState = dependencyTreeState
-        self.projectDetailsState = projectDetailsState
+        self.projectDetailsStatus = projectDetailsStatus
     }
 
     func makeNSViewController(
         context _: NSViewControllerRepresentableContext<MainSplitViewController>
     ) -> NSSplitViewController {
-        makeSplitViewController(using: dependencyTreeState, projectDetailsState: projectDetailsState)
+        makeSplitViewController(using: dependencyTreeState, projectDetailsStatus: projectDetailsStatus)
     }
 
     func updateNSViewController(
@@ -38,10 +38,10 @@ struct MainSplitViewController: NSViewControllerRepresentable {
 
 private func makeSplitViewController(
     using dependencyTreeState: Observable<DependencyTree.State>,
-    projectDetailsState: Observable<ProjectDetails.Status>
+    projectDetailsStatus: Observable<ProjectDetails.Status>
 ) -> NSSplitViewController {
     let splitViewController = NSSplitViewController()
-    splitViewController.addSplitViewItem(makeDetailsView(using: projectDetailsState))
+    splitViewController.addSplitViewItem(makeDetailsView(using: projectDetailsStatus))
     splitViewController.addSplitViewItem(makeExpandableList(using: dependencyTreeState))
 
     let splitView = NSSplitView()
@@ -53,9 +53,9 @@ private func makeSplitViewController(
 }
 
 private func makeDetailsView(
-    using projectDetailsState: Observable<ProjectDetails.Status>
+    using projectDetailsStatus: Observable<ProjectDetails.Status>
 ) -> NSSplitViewItem {
-    let hostingController = NSHostingController(rootView: DetailsView(projectDetailsState: projectDetailsState))
+    let hostingController = NSHostingController(rootView: DetailsView(projectDetailsStatus: projectDetailsStatus))
     let splitViewItem = NSSplitViewItem(viewController: hostingController)
     splitViewItem.holdingPriority = .defaultHigh
     splitViewItem.minimumThickness = 140

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
@@ -11,15 +11,15 @@ import SwiftUI
 struct MainSplitViewController: NSViewControllerRepresentable {
     typealias NSViewControllerType = NSSplitViewController
 
-    private var viewData: ObservableData<DependencyTree.State>
-    public init(viewData: ObservableData<DependencyTree.State>) {
-        self.viewData = viewData
+    private var dependencyTreeState: ObservableData<DependencyTree.State>
+    public init(dependencyTreeState: ObservableData<DependencyTree.State>) {
+        self.dependencyTreeState = dependencyTreeState
     }
 
     func makeNSViewController(
         context _: NSViewControllerRepresentableContext<MainSplitViewController>
     ) -> NSSplitViewController {
-        buildSplitViewController(using: viewData)
+        buildSplitViewController(using: dependencyTreeState)
     }
 
     func updateNSViewController(
@@ -30,10 +30,13 @@ struct MainSplitViewController: NSViewControllerRepresentable {
 
 // MARK: - Helpers
 
-private func buildSplitViewController(using viewData: ObservableData<DependencyTree.State>) -> NSSplitViewController {
+private func buildSplitViewController(
+    using dependencyTreeState: ObservableData<DependencyTree.State>
+) -> NSSplitViewController {
+
     let splitViewController = NSSplitViewController()
     splitViewController.addSplitViewItem(buildDetailsViewItem())
-    splitViewController.addSplitViewItem(buildContentViewItem(using: viewData))
+    splitViewController.addSplitViewItem(buildContentViewItem(using: dependencyTreeState))
 
     let splitView = NSSplitView()
     splitView.isVertical = true
@@ -52,8 +55,13 @@ private func buildDetailsViewItem() -> NSSplitViewItem {
     return splitViewItem
 }
 
-private func buildContentViewItem(using viewData: ObservableData<DependencyTree.State>) -> NSSplitViewItem {
-    let hostingController = NSHostingController(rootView: ExpandableListView(viewData: viewData))
+private func buildContentViewItem(
+    using dependencyTreeState: ObservableData<DependencyTree.State>
+) -> NSSplitViewItem {
+
+    let hostingController = NSHostingController(
+        rootView: ExpandableListView(dependencyTreeState: dependencyTreeState)
+    )
     let splitViewItem = NSSplitViewItem(viewController: hostingController)
 
     return splitViewItem

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
@@ -57,8 +57,6 @@ private func makeDetailsView(
 ) -> NSSplitViewItem {
     let hostingController = NSHostingController(rootView: DetailsView(projectDetailsStatus: projectDetailsStatus))
     let splitViewItem = NSSplitViewItem(viewController: hostingController)
-    splitViewItem.holdingPriority = .defaultHigh
-    splitViewItem.minimumThickness = 140
 
     return splitViewItem
 }

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
@@ -58,7 +58,7 @@ private func makeDetailsView(
     let hostingController = NSHostingController(rootView: DetailsView(projectDetailsState: projectDetailsState))
     let splitViewItem = NSSplitViewItem(viewController: hostingController)
     splitViewItem.holdingPriority = .defaultHigh
-    splitViewItem.minimumThickness = 120
+    splitViewItem.minimumThickness = 140
 
     return splitViewItem
 }

--- a/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
+++ b/Mac-App/Frontend/Frontend/Views/MainSplitView/MainSplitViewController.swift
@@ -12,11 +12,11 @@ struct MainSplitViewController: NSViewControllerRepresentable {
     typealias NSViewControllerType = NSSplitViewController
 
     private var dependencyTreeState: Observable<DependencyTree.State>
-    private var projectDetailsState: Observable<ProjectDetails.State>
+    private var projectDetailsState: Observable<ProjectDetails.Status>
 
     public init(
         dependencyTreeState: Observable<DependencyTree.State>,
-        projectDetailsState: Observable<ProjectDetails.State>
+        projectDetailsState: Observable<ProjectDetails.Status>
     ) {
         self.dependencyTreeState = dependencyTreeState
         self.projectDetailsState = projectDetailsState
@@ -38,7 +38,7 @@ struct MainSplitViewController: NSViewControllerRepresentable {
 
 private func makeSplitViewController(
     using dependencyTreeState: Observable<DependencyTree.State>,
-    projectDetailsState: Observable<ProjectDetails.State>
+    projectDetailsState: Observable<ProjectDetails.Status>
 ) -> NSSplitViewController {
     let splitViewController = NSSplitViewController()
     splitViewController.addSplitViewItem(makeDetailsView(using: projectDetailsState))
@@ -53,7 +53,7 @@ private func makeSplitViewController(
 }
 
 private func makeDetailsView(
-    using projectDetailsState: Observable<ProjectDetails.State>
+    using projectDetailsState: Observable<ProjectDetails.Status>
 ) -> NSSplitViewItem {
     let hostingController = NSHostingController(rootView: DetailsView(projectDetailsState: projectDetailsState))
     let splitViewItem = NSSplitViewItem(viewController: hostingController)

--- a/Mac-App/Mac-App/AppDelegate.swift
+++ b/Mac-App/Mac-App/AppDelegate.swift
@@ -19,7 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let contentView = InputView { value in
             BackendAPI.dispatch(DependencyPathsAction.findUrls(for: value))
 
-            let mainSplitView = MainSplitView(viewData: listViewTransformer.transformedData)
+            let mainSplitView = MainSplitView(dependencyTreeState: listViewTransformer.transformedData)
             self.window.contentView = NSHostingView(rootView: mainSplitView)
         }
 

--- a/Mac-App/Mac-App/AppDelegate.swift
+++ b/Mac-App/Mac-App/AppDelegate.swift
@@ -21,7 +21,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             let mainSplitView = MainSplitView(
                 dependencyTreeState: listViewTransformer.transformedData,
-                projectDetailsState: projectDetailsTransformer.viewInput
+                projectDetailsStatus: projectDetailsTransformer.viewInput
             )
             self.window.contentView = NSHostingView(rootView: mainSplitView)
         }

--- a/Mac-App/Mac-App/AppDelegate.swift
+++ b/Mac-App/Mac-App/AppDelegate.swift
@@ -19,7 +19,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let contentView = InputView { value in
             BackendAPI.dispatch(DependencyPathsAction.findUrls(for: value))
 
-            let mainSplitView = MainSplitView(dependencyTreeState: listViewTransformer.transformedData)
+            let mainSplitView = MainSplitView(
+                dependencyTreeState: listViewTransformer.transformedData,
+                projectDetailsState: projectDetailsTransformer.transformedData
+            )
             self.window.contentView = NSHostingView(rootView: mainSplitView)
         }
 

--- a/Mac-App/Mac-App/AppDelegate.swift
+++ b/Mac-App/Mac-App/AppDelegate.swift
@@ -21,7 +21,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             let mainSplitView = MainSplitView(
                 dependencyTreeState: listViewTransformer.transformedData,
-                projectDetailsState: projectDetailsTransformer.transformedData
+                projectDetailsState: projectDetailsTransformer.viewInput
             )
             self.window.contentView = NSHostingView(rootView: mainSplitView)
         }

--- a/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
+++ b/Mac-App/Mac-App/BackendSubscribers/registerSubscribers.swift
@@ -11,7 +11,7 @@ import Frontend
 
 func registerSubscribers() {
     BackendAPI.subscribe(listViewTransformer.stateObserver) { $0.select(DependencyTree.Data.init) }
-    BackendAPI.subscribe(projectDetailsTransformer.stateObserver) { $0.select(ProjectDetails.Data.init) }
+    BackendAPI.subscribe(projectDetailsTransformer.stateObserver) { $0.select(ProjectDetails.State.init) }
 
     startListening()
 }

--- a/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
@@ -13,7 +13,7 @@ import ReSwift
 
 final class ListViewTransformer {
     let stateObserver = StateObserver<Frontend.DependencyTree.Data>()
-    private(set) var transformedData: ObservableData<Frontend.DependencyTree.State> = .init(.initial)
+    private(set) var transformedData: Observable<Frontend.DependencyTree.State> = .init(.initial)
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {

--- a/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
@@ -31,9 +31,9 @@ final class ListViewTransformer {
 
     private func emitNewData(_ viewData: Frontend.DependencyTree.Data) {
         if viewData.dependencies.isEmpty == false {
-            transformedData.render(.success(viewData: viewData))
+            transformedData.update(to: .success(viewData: viewData))
         } else if let failure = viewData.failure {
-            transformedData.render(.failure(failure))
+            transformedData.update(to: .failure(failure))
         }
     }
 }

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -60,9 +60,12 @@ extension ProjectDetailsTransformer {
 
 extension ProjectDetails.Data {
     init(appState: AppState) {
-        let heaviestDependency = appState.dependencyGraphState.tree.sorted(by: { first, second -> Bool in
+        let heaviestDependency = appState.dependencyGraphState.tree.sorted(by: {
+            first, second -> Bool in
+
             first.dependencies.count > second.dependencies.count
-            }).first?.owner
+        }
+        ).first?.owner
         let totalDeps = appState.dependencyGraphState.tree.count
         let paths = appState.dependencyPathsState.paths
 

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -71,7 +71,8 @@ extension ProjectDetails.State {
         self.init(
             heaviestDependency: heaviestDependency ?? "",
             totalDependenciesFound: totalDeps,
-            paths: paths
+            paths: paths,
+            failure: appState.dependencyGraphState.failure
         )
     }
 }

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -30,29 +30,11 @@ final class ProjectDetailsTransformer {
     }
 
     private func emitNewState(_ state: ProjectDetails.State) {
-        let status = mapViewDataToStatus(state)
-
-        switch status {
-        case let .failure(failure):
+        if state.paths.isEmpty == false {
+            viewInput.update(to: .success(state: state))
+        } else if let failure = state.failure {
             viewInput.update(to: .failure(failure))
-        case let .success(viewData):
-            viewInput.update(to: .success(viewData: viewData))
         }
-    }
-
-    private func mapViewDataToStatus(_ data: ProjectDetails.State) -> ProjectDetailsTransformer.Status {
-        guard data.totalDependenciesFound > 0 else {
-            return .failure("No paths found!")
-        }
-
-        return .success(data)
-    }
-}
-
-extension ProjectDetailsTransformer {
-    enum Status {
-        case success(_ data: ProjectDetails.State)
-        case failure(_ failure: String)
     }
 }
 

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -34,9 +34,9 @@ final class ProjectDetailsTransformer {
 
         switch status {
         case let .failure(failure):
-            transformedData.render(.failure(failure))
+            transformedData.update(to: .failure(failure))
         case let .success(viewData):
-            transformedData.render(.success(viewData: viewData))
+            transformedData.update(to: .success(viewData: viewData))
         }
     }
 

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -12,7 +12,7 @@ import Frontend
 import ReSwift
 
 final class ProjectDetailsTransformer {
-    let stateObserver = StateObserver<ProjectDetails.Data>()
+    let stateObserver = StateObserver<ProjectDetails.State>()
     private(set) var viewInput: Observable<ProjectDetails.Status> = .init(.initial)
     private var cancellable: AnyCancellable = AnyCancellable {}
 
@@ -29,7 +29,7 @@ final class ProjectDetailsTransformer {
         cancellable.cancel()
     }
 
-    private func emitNewData(_ viewData: ProjectDetails.Data) {
+    private func emitNewData(_ viewData: ProjectDetails.State) {
         let status = mapViewDataToStatus(viewData)
 
         switch status {
@@ -40,7 +40,7 @@ final class ProjectDetailsTransformer {
         }
     }
 
-    private func mapViewDataToStatus(_ data: ProjectDetails.Data) -> ProjectDetailsTransformer.Status {
+    private func mapViewDataToStatus(_ data: ProjectDetails.State) -> ProjectDetailsTransformer.Status {
         guard data.totalDependenciesFound > 0 else {
             return .failure("No paths found!")
         }
@@ -51,14 +51,14 @@ final class ProjectDetailsTransformer {
 
 extension ProjectDetailsTransformer {
     enum Status {
-        case success(_ data: ProjectDetails.Data)
+        case success(_ data: ProjectDetails.State)
         case failure(_ failure: String)
     }
 }
 
 // MARK: - Mapper from AppState to subscriber state (view data for UI)
 
-extension ProjectDetails.Data {
+extension ProjectDetails.State {
     init(appState: AppState) {
         let heaviestDependency = appState.dependencyGraphState.tree.sorted(by: {
             first, second -> Bool in
@@ -76,4 +76,4 @@ extension ProjectDetails.Data {
     }
 }
 
-extension ProjectDetails.Data: StateType {}
+extension ProjectDetails.State: StateType {}

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -13,7 +13,7 @@ import ReSwift
 
 final class ProjectDetailsTransformer {
     let stateObserver = StateObserver<ProjectDetails.Data>()
-    private(set) var transformedData: Observable<ProjectDetails.State> = .init(.initial)
+    private(set) var viewInput: Observable<ProjectDetails.State> = .init(.initial)
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {
@@ -34,9 +34,9 @@ final class ProjectDetailsTransformer {
 
         switch status {
         case let .failure(failure):
-            transformedData.update(to: .failure(failure))
+            viewInput.update(to: .failure(failure))
         case let .success(viewData):
-            transformedData.update(to: .success(viewData: viewData))
+            viewInput.update(to: .success(viewData: viewData))
         }
     }
 

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -64,8 +64,7 @@ extension ProjectDetails.Data {
             first, second -> Bool in
 
             first.dependencies.count > second.dependencies.count
-        }
-        ).first?.owner
+        }).first?.owner
         let totalDeps = appState.dependencyGraphState.tree.count
         let paths = appState.dependencyPathsState.paths
 

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -18,10 +18,10 @@ final class ProjectDetailsTransformer {
 
     func startListening() {
         cancellable = stateObserver.$currentState.sink {
-            [weak self] appState in
+            [weak self] projectDetailsState in
 
-            precondition(appState != nil, "State observer should always have an initial state provided by the Backend!")
-            self?.emitNewData(appState!)
+            precondition(projectDetailsState != nil, "State observer should always have an initial state provided by the Backend!")
+            self?.emitNewData(projectDetailsState!)
         }
     }
 

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -13,7 +13,7 @@ import ReSwift
 
 final class ProjectDetailsTransformer {
     let stateObserver = StateObserver<ProjectDetails.Data>()
-    private(set) var transformedData: ObservableData<ProjectDetails.State> = .init(.initial)
+    private(set) var transformedData: Observable<ProjectDetails.State> = .init(.initial)
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -13,7 +13,7 @@ import ReSwift
 
 final class ProjectDetailsTransformer {
     let stateObserver = StateObserver<ProjectDetails.Data>()
-    private(set) var viewInput: Observable<ProjectDetails.State> = .init(.initial)
+    private(set) var viewInput: Observable<ProjectDetails.Status> = .init(.initial)
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -21,7 +21,7 @@ final class ProjectDetailsTransformer {
             [weak self] projectDetailsState in
 
             precondition(projectDetailsState != nil, "State observer should always have an initial state provided by the Backend!")
-            self?.emitNewData(projectDetailsState!)
+            self?.emitNewState(projectDetailsState!)
         }
     }
 
@@ -29,8 +29,8 @@ final class ProjectDetailsTransformer {
         cancellable.cancel()
     }
 
-    private func emitNewData(_ viewData: ProjectDetails.State) {
-        let status = mapViewDataToStatus(viewData)
+    private func emitNewState(_ state: ProjectDetails.State) {
+        let status = mapViewDataToStatus(state)
 
         switch status {
         case let .failure(failure):


### PR DESCRIPTION
This PR is a bit hairy due to some renaming. Ideally this should have been tackled in a separate piece of work, but it made more sense to integrate that here as the context of why the previous name wasn't quite working is a bit more noticeable. 

- `ObservableData` was renamed to `Observable` -> The underlying intention is to further expand the usage of this building block to not only data, but state or anything else that can be observed. 
- It's generic `associatedtype` was also renamed to `input` 

- Added missing copyright headers

- Introduced `DetailsView` which shows some relevant/interesting stats of the project just scanned. 

- Introduced `LoadingView` which encapsulates the common standalone `ActivityIndicator` + some additional attributes. 

A couple of screenshots of how it looks now. 
<img width="1920" alt="Screenshot 2020-05-21 at 12 50 48" src="https://user-images.githubusercontent.com/6764091/82551920-7842d400-9b61-11ea-814d-a735561a62a4.png">
<img width="1918" alt="Screenshot 2020-05-21 at 12 50 56" src="https://user-images.githubusercontent.com/6764091/82551927-7c6ef180-9b61-11ea-84f9-ff3f36d40e73.png">

