### PR TITLE
Use custom queue instead of global

### DIFF
--- a/Mac-App/Backend/Backend/BackendAPI/Middleware/DependencyGraphSideEffects/DependencyGraphSideEffects.swift
+++ b/Mac-App/Backend/Backend/BackendAPI/Middleware/DependencyGraphSideEffects/DependencyGraphSideEffects.swift
@@ -18,7 +18,7 @@ func dependencyGraphSideEffects(parser: @escaping SwiftDepsParserType) -> Middle
 
                 switch action {
                 case let DependencyGraphAction.mapFrom(swiftDeps):
-                    dispatchAsyncOnGlobal {
+                    dispatchAsyncOnBackendQueue {
                         let parsedSwiftDeps = parser(swiftDeps)
                         dispatchFuction(DependencyGraphAction.set(parsedSwiftDeps))
                     }

--- a/Mac-App/Backend/Backend/BackendAPI/Middleware/FindProjectOutputDirsSideEffects/FindProjectOutputDirsSideEffects.swift
+++ b/Mac-App/Backend/Backend/BackendAPI/Middleware/FindProjectOutputDirsSideEffects/FindProjectOutputDirsSideEffects.swift
@@ -18,7 +18,7 @@ func findProjectOutputDirsSideEffects(finder: @escaping ProjectOutputFinderType)
 
                 switch action {
                 case let DependencyPathsAction.findUrls(for: project):
-                    dispatchAsyncOnGlobal {
+                    dispatchAsyncOnBackendQueue {
                         let urls = finder(
                             DefaultSearchValues.derivedDataPaths,
                             project,

--- a/Mac-App/Backend/Backend/BackendAPI/Middleware/ParseSwiftDepsSideEffects/ParseSwiftDepsSideEffects.swift
+++ b/Mac-App/Backend/Backend/BackendAPI/Middleware/ParseSwiftDepsSideEffects/ParseSwiftDepsSideEffects.swift
@@ -18,7 +18,7 @@ func parseSwiftDepsSideEffects(yamlParser: @escaping YamlParserType) -> Middlewa
 
                 switch action {
                 case let SwiftDepsAction.parseFrom(paths: url):
-                    dispatchAsyncOnGlobal {
+                    dispatchAsyncOnBackendQueue {
                         let parsedUrls = yamlParser(url)
                         if parsedUrls.isEmpty == false {
                             dispatchFuction(SwiftDepsAction.set(parsedUrls))
@@ -27,7 +27,7 @@ func parseSwiftDepsSideEffects(yamlParser: @escaping YamlParserType) -> Middlewa
                         }
                     }
                 case let SwiftDepsAction.set(swiftDeps):
-                    dispatchAsyncOnGlobal {
+                    dispatchAsyncOnBackendQueue {
                         dispatchFuction(DependencyGraphAction.mapFrom(deps: swiftDeps))
                     }
                 default: break


### PR DESCRIPTION
Use labeled queue defined in `Backend` instead of global. 