### PR TITLE
Do not include twice dependency owner

### DIFF
--- a/Mac-App/Backend/Backend/Parsers/SwiftDepsParser/SwiftDepsParser.swift
+++ b/Mac-App/Backend/Backend/Parsers/SwiftDepsParser/SwiftDepsParser.swift
@@ -28,8 +28,11 @@ func parseSwiftDeps(_ swiftDeps: [SwiftDeps]) -> [DependencyTree] {
                     .excludeSystemSymbolsPrefixes()
                     .filterOcurrancesOf(name)
                     .map(DependencyTree.Dependency.init)
-
-                result.append(DependencyTree(owner: name, dependencies: deps))
+                
+                let tree = DependencyTree(owner: name, dependencies: deps)
+                if result.contains(tree) == false {
+                    result.append(tree)
+                }
             }
         }
     }


### PR DESCRIPTION
This makes a difference in large projects. 