### PR TITLE
Small clean up

### DIFF
--- a/Mac-App/Mac-App/StateObserver/StateObserver.swift
+++ b/Mac-App/Mac-App/StateObserver/StateObserver.swift
@@ -13,7 +13,13 @@ final class StateObserver<State: StateType & Equatable>: StoreSubscriber {
     typealias StoreSubscriberStateType = State
 
     @Published
-    private(set) var currentState: State!
+    private(set) var currentState: State
+
+    init(state: State) {
+        currentState = state
+    }
+
+    // MARK: - Public API
 
     func newState(state: State) {
         guard currentState != state else { return }

--- a/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
@@ -12,17 +12,12 @@ import Frontend
 import ReSwift
 
 final class ListViewTransformer: StateTransforming, StateRepresentableViewInput, StateSubscription {
-    let stateObserver = StateObserver<Frontend.DependencyTree.State>()
+    let stateObserver = StateObserver<Frontend.DependencyTree.State>(state: DependencyTree.State.initialState)
     private(set) var viewInput: Observable<Frontend.DependencyTree.Status> = .init(.initial)
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {
-        cancellable = stateObserver.$currentState.sink {
-            [weak self] appState in
-
-            precondition(appState != nil, "State observer should always have an initial state provided by the Backend!")
-            self?.emitNewState(appState!)
-        }
+        cancellable = stateObserver.$currentState.sink { [weak self] in self?.emitNewState($0) }
     }
 
     func stopListening() {
@@ -61,3 +56,6 @@ extension Frontend.DependencyTree.State {
 }
 
 extension Frontend.DependencyTree.State: StateType {}
+extension Frontend.DependencyTree.State {
+    static let initialState = DependencyTree.State(dependencies: [], filteredDependencies: [], failure: nil)
+}

--- a/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ListViewTransformer.swift
@@ -17,7 +17,7 @@ final class ListViewTransformer: StateTransforming, StateRepresentableViewInput,
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {
-        cancellable = stateObserver.$currentState.sink { [weak self] in self?.emitNewState($0) }
+        cancellable = stateObserver.$currentState.sink { [unowned self] in self.emitNewState($0) }
     }
 
     func stopListening() {

--- a/Mac-App/Mac-App/Transformers/NavigationTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/NavigationTransformer.swift
@@ -32,7 +32,7 @@ final class NavigationTransformer: StateTransforming, StateRepresentableViewInpu
     }
 
     func startListening() {
-        cancellable = stateObserver.$currentState.sink { [weak self] in self?.emitNewState($0) }
+        cancellable = stateObserver.$currentState.sink { [unowned self] in self.emitNewState($0) }
     }
 
     func stopListening() {

--- a/Mac-App/Mac-App/Transformers/NavigationTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/NavigationTransformer.swift
@@ -13,7 +13,7 @@ import ReSwift
 import SwiftUI
 
 final class NavigationTransformer: StateTransforming, StateRepresentableViewInput, StateSubscription {
-    let stateObserver = StateObserver<Frontend.NavigationData.State>()
+    let stateObserver = StateObserver<Frontend.NavigationData.State>(state: NavigationData.State.initialState)
     let viewInput: Observable<NavigationData.Status> = .init(.initial)
     private var cancellable: AnyCancellable = AnyCancellable {}
 
@@ -32,12 +32,7 @@ final class NavigationTransformer: StateTransforming, StateRepresentableViewInpu
     }
 
     func startListening() {
-        cancellable = stateObserver.$currentState.sink {
-            [weak self] appState in
-
-            precondition(appState != nil, "State observer should always have an initial state provided by the Backend!")
-            self?.emitNewState(appState!)
-        }
+        cancellable = stateObserver.$currentState.sink { [weak self] in self?.emitNewState($0) }
     }
 
     func stopListening() {
@@ -102,3 +97,6 @@ extension Frontend.NavigationData.State {
 }
 
 extension Frontend.NavigationData.State: StateType {}
+extension Frontend.NavigationData.State {
+    static let initialState = NavigationData.State(currentNode: NavigationData.Node.startup, previousNode: nil)
+}

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -12,17 +12,12 @@ import Frontend
 import ReSwift
 
 final class ProjectDetailsTransformer: StateTransforming, StateRepresentableViewInput, StateSubscription {
-    let stateObserver = StateObserver<ProjectDetails.State>()
+    let stateObserver = StateObserver<ProjectDetails.State>(state: ProjectDetails.State.initialState)
     private(set) var viewInput: Observable<ProjectDetails.Status> = .init(.initial)
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {
-        cancellable = stateObserver.$currentState.sink {
-            [weak self] projectDetailsState in
-
-            precondition(projectDetailsState != nil, "State observer should always have an initial state provided by the Backend!")
-            self?.emitNewState(projectDetailsState!)
-        }
+        cancellable = stateObserver.$currentState.sink { [weak self] in self?.emitNewState($0) }
     }
 
     func stopListening() {
@@ -60,3 +55,11 @@ extension ProjectDetails.State {
 }
 
 extension ProjectDetails.State: StateType {}
+extension ProjectDetails.State {
+    static let initialState = ProjectDetails.State(
+        heaviestDependency: "",
+        totalDependenciesFound: -1,
+        paths: [],
+        failure: nil
+    )
+}

--- a/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
+++ b/Mac-App/Mac-App/Transformers/ProjectDetailsTransformer.swift
@@ -17,7 +17,7 @@ final class ProjectDetailsTransformer: StateTransforming, StateRepresentableView
     private var cancellable: AnyCancellable = AnyCancellable {}
 
     func startListening() {
-        cancellable = stateObserver.$currentState.sink { [weak self] in self?.emitNewState($0) }
+        cancellable = stateObserver.$currentState.sink { [unowned self] in self.emitNewState($0) }
     }
 
     func stopListening() {


### PR DESCRIPTION
Prevents unwrapping generic state by providing an initialiser to enforce consumers to provide an initial value. 